### PR TITLE
[SRE-196] add migration hook

### DIFF
--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.runMigrations }}
+
 {{/* Go Templates do not support variable updating, so we simulate it using dictionaries */}}
 {{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false -}}
 {{- if .Values.envVars -}}
@@ -34,4 +36,4 @@ spec:
           - name: {{ $key }}
             value: {{ quote $value }}
           {{- end }}
-
+{{- end }}

--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -6,7 +6,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: db-migrate
+  name: "{{ .Values.applicationName }}-db-migrate"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
   activeDeadlineSeconds: 300
   backoffLimit: 1
   template:
-    name: db-migrate
+    name: "{{ .Values.applicationName }}-db-migrate"
     spec:
       restartPolicy: Never
       containers:

--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -12,12 +12,13 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   activeDeadlineSeconds: 300
+  backoffLimit: 1
   template:
     name: db-migrate
     spec:
       restartPolicy: Never
       containers:
-        - name: db-migrate
+        - name: "{{ .Values.applicationName }}-db-migrate"
           {{- $repo := required "containerImage.repository is required" .Values.containerImage.repository }}
           {{- $tag := required "containerImage.tag is required" .Values.containerImage.tag }}
           image: "{{ $repo }}:{{ $tag }}"
@@ -25,7 +26,7 @@ spec:
             - bundle
             - exec
             - rails
-            - db:migrate:primary
+            - db:migrate
           {{- /* START ENV VAR LOGIC */ -}}
           {{- if index $hasInjectionTypes "hasEnvVars" }}
           env:

--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -1,5 +1,5 @@
 {{/* Go Templates do not support variable updating, so we simulate it using dictionaries */}}
-{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false "hasIRSA" false "exposePorts" false -}}
+{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false -}}
 {{- if .Values.envVars -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
 {{- end -}}
@@ -22,11 +22,10 @@ spec:
           {{- $repo := required "containerImage.repository is required" .Values.containerImage.repository }}
           {{- $tag := required "containerImage.tag is required" .Values.containerImage.tag }}
           image: "{{ $repo }}:{{ $tag }}"
+          {{- if .Values.hookCommand }}
           command:
-            - bundle
-            - exec
-            - rails
-            - db:migrate
+{{ toYaml .Values.hookCommand | indent 12 }}
+          {{- end }}
           {{- /* START ENV VAR LOGIC */ -}}
           {{- if index $hasInjectionTypes "hasEnvVars" }}
           env:

--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.runMigrations }}
+{{- if .Values.enableMigrationsHook }}
 
 {{/* Go Templates do not support variable updating, so we simulate it using dictionaries */}}
 {{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false -}}

--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -22,9 +22,9 @@ spec:
           {{- $repo := required "containerImage.repository is required" .Values.containerImage.repository }}
           {{- $tag := required "containerImage.tag is required" .Values.containerImage.tag }}
           image: "{{ $repo }}:{{ $tag }}"
-          {{- if .Values.hookCommand }}
+          {{- if .Values.migrateCommand }}
           command:
-{{ toYaml .Values.hookCommand | indent 12 }}
+{{ toYaml .Values.migrateCommand | indent 12 }}
           {{- end }}
           {{- /* START ENV VAR LOGIC */ -}}
           {{- if index $hasInjectionTypes "hasEnvVars" }}
@@ -34,3 +34,4 @@ spec:
           - name: {{ $key }}
             value: {{ quote $value }}
           {{- end }}
+

--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -1,3 +1,8 @@
+{{/* Go Templates do not support variable updating, so we simulate it using dictionaries */}}
+{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false "hasIRSA" false "exposePorts" false -}}
+{{- if .Values.envVars -}}
+  {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+{{- end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  activeDeadlineSeconds: 300
+  template:
+    name: db-migrate
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: db-migrate
+          image: "{{ $repo }}:{{ $tag }}"
+          command:
+            - bundle
+            - exec
+            - rails
+            - db:migrate:primary
+          {{- /* START ENV VAR LOGIC */ -}}
+          {{- if index $hasInjectionTypes "hasEnvVars" }}
+          env:
+          {{- end }}
+          {{- range $key, $value := .Values.envVars }}
+          - name: {{ $key }}
+            value: {{ quote $value }}
+          {{- end }}

--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -13,6 +13,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: db-migrate
+          {{- $repo := required "containerImage.repository is required" .Values.containerImage.repository }}
+          {{- $tag := required "containerImage.tag is required" .Values.containerImage.tag }}
           image: "{{ $repo }}:{{ $tag }}"
           command:
             - bundle

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -321,3 +321,24 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  activeDeadlineSeconds: 300
+  template:
+    name: db-migrate
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: db-migrate
+          image: "{{ $repo }}:{{ $tag }}"
+          command:
+            - bundle
+            - exec
+            - rails
+            - db:migrate:primary

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -321,32 +321,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: db-migrate
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
-spec:
-  activeDeadlineSeconds: 300
-  template:
-    name: db-migrate
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: db-migrate
-          image: "{{ $repo }}:{{ $tag }}"
-          command:
-            - bundle
-            - exec
-            - rails
-            - db:migrate:primary
-          {{- /* START ENV VAR LOGIC */ -}}
-          {{- if index $hasInjectionTypes "hasEnvVars" }}
-          env:
-          {{- end }}
-          {{- range $key, $value := .Values.envVars }}
-          - name: {{ $key }}
-            value: {{ quote $value }}
-          {{- end }}

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -342,3 +342,11 @@ spec:
             - exec
             - rails
             - db:migrate:primary
+          {{- /* START ENV VAR LOGIC */ -}}
+          {{- if index $hasInjectionTypes "hasEnvVars" }}
+          env:
+          {{- end }}
+          {{- range $key, $value := .Values.envVars }}
+          - name: {{ $key }}
+            value: {{ quote $value }}
+          {{- end }}


### PR DESCRIPTION
This PR adds a `pre-install` and `pre-upgrade` [Helm hook](https://v2.helm.sh/docs/charts_hooks/#hooks) to our forked Helm Kubernetes Services chart.

The motivation behind this change is that we want to run rails migrations each time we deploy an application to EKS. However, the solution suggested in sample app backend - Flyway - would not work for us since we don't run migrations in plain SQL and we don't want to bake migrations in containers as a start up command. 

After doing some research (more on [SRE-196](https://smileio.atlassian.net/browse/SRE-196)), the best way really is to have a Helm Chart hook that if fails prevents the deployment from happening.

Gruntworks Helm Chart we use does not have any hooks or means to inject such thing at the moment. As confirmed with them in [Slack](https://gruntwork-community.slack.com/archives/CHH9Y3Z62/p1589336042020600?thread_ts=1589230353.478700&cid=CHH9Y3Z62), one solution would be to fork their repo and add that hook. Another one, an umbrella chart, is not something we're very familiar with at the moment so we went wit the fork.

Here are the highlights of this hook:
- runs a K8S job on `pre-install` (new app) and on `pre-upgrade` (updating app version) events
- has a timeout of 5 minutes, @undergroundwebdesigns is that enough?
- injects all ENVs available from the deployment (i.e. the application)
- allows for passing in a command as sometimes we want not only run a `db:migrate`but something else as it is the case with `smile-bi`
- retries once if failed
- the job is deleted only if successful, otherwise it will hang out and wait for debugging