### PR TITLE
Sre 281 update migration hook

### DIFF
--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -17,7 +17,18 @@ spec:
   backoffLimit: 1
   template:
     name: "{{ .Values.applicationName }}-db-migrate"
+    {{- with .Values.podAnnotations }}
+    annotations:
+    {{ toYaml . | indent 8 }}
+    {{- end }}
     spec:
+      {{- if gt (len .Values.serviceAccount.name) 0 }}
+      serviceAccountName: "{{ .Values.serviceAccount.name }}"
+      {{- end }}
+      {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
+
       restartPolicy: Never
       containers:
         - name: "{{ .Values.applicationName }}-db-migrate"

--- a/charts/k8s-service/templates/dbmigrate.yaml
+++ b/charts/k8s-service/templates/dbmigrate.yaml
@@ -17,10 +17,11 @@ spec:
   backoffLimit: 1
   template:
     name: "{{ .Values.applicationName }}-db-migrate"
-    {{- with .Values.podAnnotations }}
-    annotations:
-    {{ toYaml . | indent 8 }}
-    {{- end }}
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
     spec:
       {{- if gt (len .Values.serviceAccount.name) 0 }}
       serviceAccountName: "{{ .Values.serviceAccount.name }}"


### PR DESCRIPTION
This PR adds `service account` and `pod annotations` to the migration hook. These values are accessible from the chart variables.

Tested in sandbox.