### PR TITLE
Sre 316 make deployments optional

### DIFF
--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- /* In some cases, like in CI/CD, we may want to skip the main Deployment and just let the dbmigrate hook to run. */ -}}
 {{- if .Values.enableDeployment }}
 
 {{- /*

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if !.Values.disableDeployment }}
+{{- if .Values.enableDeployment }}
 
 {{- /*
 The main Deployment Controller for the application being deployed. This resource manages the creation and replacement

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- if !.Values.disableDeployment }}
+
 {{- /*
 The main Deployment Controller for the application being deployed. This resource manages the creation and replacement
 of the Pods backing your application.
@@ -321,3 +323,5 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+
+{{- end }}


### PR DESCRIPTION
This PR adds a possibility to skip the main deployment controller. This comes in handy when we look only for running a hook like we want to do in CI/CD setup. 

[SRE-316](https://smileio.atlassian.net/browse/SRE-316)