### PR TITLE
Allow custom deployment and pod labels to be set.

### DIFF
--- a/charts/k8s-service/Chart.yaml
+++ b/charts/k8s-service/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-service
 description: A Helm chart to package your application container for Kubernetes
 # This will be updated with the release tag in the CI/CD pipeline before publishing. This has to be a valid semver for
 # the linter to accept.
-version: 0.0.1-replace
+version: 0.1.2-smile-labels-pre
 home: https://github.com/gruntwork-io/helm-kubernetes-services
 maintainers:
   - name: Gruntwork

--- a/charts/k8s-service/templates/canarydeployment.yaml
+++ b/charts/k8s-service/templates/canarydeployment.yaml
@@ -74,6 +74,9 @@ metadata:
     app.kubernetes.io/name: {{ include "k8s-service.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.deploymentLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- with .Values.deploymentAnnotations }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -91,6 +94,9 @@ spec:
         app.kubernetes.io/name: {{ include "k8s-service.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         gruntwork.io/deployment-type: canary
+        {{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
 
       {{- with .Values.podAnnotations }}
       annotations:

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -69,6 +69,9 @@ metadata:
     app.kubernetes.io/name: {{ include "k8s-service.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.deploymentLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- with .Values.deploymentAnnotations }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -86,6 +89,9 @@ spec:
         app.kubernetes.io/name: {{ include "k8s-service.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         gruntwork.io/deployment-type: main
+        {{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
 
       {{- with .Values.podAnnotations }}
       annotations:

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -168,10 +168,20 @@ canary: {}
 # point in time. For example, setting to 3 will signal Kubernetes (via the Deployment contoller) to maintain 3 pods.
 replicaCount: 1
 
+# deploymentLables will add the provided map to the labels for the Deployment resource created by this chart.
+# The keys and values are free form, but subject to the limitations of Kubernetes resource labels.
+# NOTE: This variable is injected directly into the deployment spec.
+deploymentLabels: {}
+
 # deploymentAnnotations will add the provided map to the annotations for the Deployment resource created by this chart.
 # The keys and values are free form, but subject to the limitations of Kubernetes resource annotations.
 # NOTE: This variable is injected directly into the deployment spec.
 deploymentAnnotations: {}
+
+# podLabels will add the provided map to the labels for the Pod resource created by the Deployment.
+# The keys and values are free form, but subject to the limitations of Kubernetes resource lables.
+# NOTE: This variable is injected directly into the pod spec.
+podLabels: {}
 
 # podAnnotations will add the provided map to the annotations for the Pod resource created by the Deployment.
 # The keys and values are free form, but subject to the limitations of Kubernetes resource annotations.


### PR DESCRIPTION
Allows us to set custom labels on deployments and pods. Not only will this make it easier for us to find our deployments and pods via custom criteria, it is also required for proper DataDog tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging?tab=kubernetes