### PR TITLE
Allow passing labels and annotations to HPA

### DIFF
--- a/charts/k8s-service/Chart.yaml
+++ b/charts/k8s-service/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-service
 description: A Helm chart to package your application container for Kubernetes
 # This will be updated with the release tag in the CI/CD pipeline before publishing. This has to be a valid semver for
 # the linter to accept.
-version: 0.1.2-smile-hpa
+version: 0.1.2-smile-hpa-3
 home: https://github.com/gruntwork-io/helm-kubernetes-services
 maintainers:
   - name: Gruntwork

--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -4,6 +4,20 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "k8s-service.fullname" . }}
   namespace: {{ $.Release.Namespace }}
+  labels:
+    # These labels are required by helm. You can read more about required labels in the chart best practices guide:
+    # https://docs.helm.sh/chart_best_practices/#standard-labels
+    helm.sh/chart: {{ include "k8s-service.chart" . }}
+    app.kubernetes.io/name: {{ include "k8s-service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.hpaLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.hpaAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -188,6 +188,16 @@ podLabels: {}
 # NOTE: This variable is injected directly into the pod spec.
 podAnnotations: {}
 
+# hpaLabels will add the provided map to the labels for the HPA resource created if configured.
+# The keys and values are free form, but subject to the limitations of Kubernetes resource labels.
+# NOTE: This variable is injected directly into the HPA spec.
+hpaLabels: {}
+
+# hpaAnnotations will add the provided map to the annotations for the HPA resource created if configured.
+# The keys and values are free form, but subject to the limitations of Kubernetes resource annotations.
+# NOTE: This variable is injected directly into the HPA spec.
+hpaAnnotations: {}
+
 # minPodsAvailable specifies the minimum number of pods that should be available at any given point in time. This is
 # used to configure a PodDisruptionBudget for the included pod. See
 # https://blog.gruntwork.io/avoiding-outages-in-your-kubernetes-cluster-using-poddisruptionbudgets-ef6a4baa5085


### PR DESCRIPTION
This PR allows passsing labels and annotations to the HorizontalPodAutoscaler resources created by the helm chart.