### PR TITLE
[SRE-572] Fix issue with web pod

### DIFF
--- a/charts/k8s-service/Chart.yaml
+++ b/charts/k8s-service/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-service
 description: A Helm chart to package your application container for Kubernetes
 # This will be updated with the release tag in the CI/CD pipeline before publishing. This has to be a valid semver for
 # the linter to accept.
-version: 0.1.2-smile-deploy-strat-4
+version: 0.1.2-smile-deploy-strat-5
 home: https://github.com/gruntwork-io/helm-kubernetes-services
 maintainers:
   - name: Gruntwork

--- a/charts/k8s-service/templates/_helpers.tpl
+++ b/charts/k8s-service/templates/_helpers.tpl
@@ -14,7 +14,7 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "k8s-service.fullname" -}}
   {{- $name := required "applicationName is required" .Values.applicationName -}}
-  {{- if contains $name .Release.Name -}}
+  {{- if hasSuffix $name .Release.Name -}}
     {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
   {{- else -}}
     {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}


### PR DESCRIPTION
- Use `hasSuffix` instead of `contains` on the fullname helper in order to allow smile-web* apps to have proper names for their web pods.